### PR TITLE
Add ssl_timeout

### DIFF
--- a/lib/http-cage.rb
+++ b/lib/http-cage.rb
@@ -5,6 +5,7 @@ require 'net/http'
 module HTTPCage
   @connection = 60
   @request = 60
+  @ssl = 60
 
   def self.connection
     @connection
@@ -14,9 +15,14 @@ module HTTPCage
     @request
   end
 
+  def self.ssl
+    @ssl
+  end
+
   def self.timeout(args)
     @connection = args[:connection]
     @request = args[:request]
+    @ssl = args[:ssl]
     apply
   end
 

--- a/lib/http-cage/patch.rb
+++ b/lib/http-cage/patch.rb
@@ -6,6 +6,7 @@ module HTTPCage
       super(*args, &block)
       self.open_timeout = HTTPCage.connection
       self.read_timeout = HTTPCage.request
+      self.ssl_timeout  = HTTPCage.ssl
     end
   end
 end

--- a/test/spec/httpcage_spec.rb
+++ b/test/spec/httpcage_spec.rb
@@ -4,20 +4,22 @@ require 'uri'
 
 describe 'HTTPCage' do
   before do
-    HTTPCage.timeout(connection: 1, request: 2)
+    HTTPCage.timeout(connection: 1, request: 2, ssl: 3)
   end
 
   it 'overrides Net::HTTP timeouts' do
     client = Net::HTTP.new('google.com')
     client.open_timeout.must_equal 1
     client.read_timeout.must_equal 2
+    client.ssl_timeout.must_equal 3
   end
 
   it 'can be overridden by another cage' do
-    HTTPCage.timeout(connection: 10, request: 20)
+    HTTPCage.timeout(connection: 10, request: 20, ssl: 30)
     client = Net::HTTP.new('google.com')
     client.open_timeout.must_equal 10
     client.read_timeout.must_equal 20
+    client.ssl_timeout.must_equal 30
   end
 
   it 'will not timeout on a routable address' do


### PR DESCRIPTION
Allows configuring [`ssl_timeout`](https://ruby-doc.org/stdlib-2.6.5/libdoc/net/http/rdoc/Net/HTTP.html#ssl_timeout-attribute-method)